### PR TITLE
vspmif-user-module, qosif-user-module: fix header installation

### DIFF
--- a/meta-rcar-gen3/recipes-bsp/qos/files/0001-Do-not-copy-header-files-to-builddir.patch
+++ b/meta-rcar-gen3/recipes-bsp/qos/files/0001-Do-not-copy-header-files-to-builddir.patch
@@ -1,0 +1,25 @@
+From 6f800a1eb8bb032b0db4b922de3c665e3ef1fc31 Mon Sep 17 00:00:00 2001
+From: Frederico Cadete <frederico.cadete@awtce.be>
+Date: Tue, 5 Jul 2016 16:37:27 +0200
+Subject: [PATCH] Do not copy header files to builddir
+
+Signed-off-by: Frederico Cadete <frederico.cadete@awtce.be>
+---
+ qos_if-module/files/qos_if/if/Makefile | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/qos_if-module/files/qos_if/if/Makefile b/qos_if-module/files/qos_if/if/Makefile
+index 7fd88ce..67e1ac3 100644
+--- a/qos_if-module/files/qos_if/if/Makefile
++++ b/qos_if-module/files/qos_if/if/Makefile
+@@ -1,6 +1,5 @@
+ all:
+-	$(CP) ../include/qos_public.h $(BUILDDIR)/include/
+-	${CC} -fPIC -c qos_lib.c -I$(BUILDDIR)/include -Wall
++	${CC} -fPIC -c qos_lib.c -I../include -Wall
+ 	${CC} -shared -Wl,-soname=libqos.so.1 -o libqos.so.1.0.0 qos_lib.o
+ 	ln -s ./libqos.so.1.0.0 libqos.so.1
+ 	ln -s ./libqos.so.1 libqos.so
+-- 
+2.5.0
+

--- a/meta-rcar-gen3/recipes-bsp/qos/qosif-user-module.bb
+++ b/meta-rcar-gen3/recipes-bsp/qos/qosif-user-module.bb
@@ -11,6 +11,10 @@ QOSIF_LIB_DIR = "qos_if-module/files/qos_if/if"
 
 EXTRA_OEMAKE = "ARCH=${TARGET_ARCH}"
 
+SRC_URI += "file://0001-Do-not-copy-header-files-to-builddir.patch"
+
+includedir="/usr/local/include"
+
 # do_configure() nothing
 do_configure[noexec] = "1"
 
@@ -33,27 +37,6 @@ do_install() {
     ln -sf libqos.so.1 libqos.so
 
     # Copy shared header files
-    install -m 644 ${BUILDDIR}/include/qos_public.h ${D}/usr/local/include
+    install -m 644 ${S}/qos_if-module/files/qos_if/include/qos_public.h ${D}/usr/local/include
 }
 
-PACKAGES = " \
-    ${PN} \
-    ${PN}-dev \
-    ${PN}-dbg \
-"
-
-FILES_${PN} = " \
-    ${libdir}/libqos.so* \
-"
-
-FILES_${PN}-dev = " \
-    /usr/local/include \
-    /usr/local/include/*.h \
-    ${libdir}/libqos.so* \
-"
-
-FILES_${PN}-dbg = " \
-    ${libdir}/.debug/* \
-"
-
-INSANE_SKIP_${PN} = "dev-so"

--- a/meta-rcar-gen3/recipes-multimedia/vspmif-module/files/0001-Do-not-copy-header-files-to-builddir.patch
+++ b/meta-rcar-gen3/recipes-multimedia/vspmif-module/files/0001-Do-not-copy-header-files-to-builddir.patch
@@ -1,0 +1,33 @@
+From b2ab247f17274ae6cf5c4554b2f5b55e78f32e92 Mon Sep 17 00:00:00 2001
+From: Frederico Cadete <frederico.cadete@awtce.be>
+Date: Tue, 14 Jun 2016 09:37:44 +0200
+Subject: [PATCH] Do not copy header files to builddir
+
+Signed-off-by: Frederico Cadete <frederico.cadete@awtce.be>
+---
+ vspm_if-module/files/vspm_if/if/Makefile | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/vspm_if-module/files/vspm_if/if/Makefile b/vspm_if-module/files/vspm_if/if/Makefile
+index 436afcb..ddf10e7 100644
+--- a/vspm_if-module/files/vspm_if/if/Makefile
++++ b/vspm_if-module/files/vspm_if/if/Makefile
+@@ -1,13 +1,9 @@
+ all:
+-	$(CP) ../include/vspm_public.h $(BUILDDIR)/include
+-	$(CP) ../include/vsp_drv.h $(BUILDDIR)/include
+-	$(CP) ../include/fdp_drv.h $(BUILDDIR)/include
+ ifeq ($(VSPM_LEGACY_IF),1)
+-	$(CP) ../include/fdpm_api.h $(BUILDDIR)/include
+-	${CC} -fPIC -c vspm_api.c vspm_api_vsp.c vspm_api_fdp.c -I$(BUILDDIR)/include -Wall
++	${CC} -fPIC -c vspm_api.c vspm_api_vsp.c vspm_api_fdp.c -I../include -Wall
+ 	${CC} -shared -Wl,-soname=libvspm.so.1 -o libvspm.so.1.0.0 vspm_api.o vspm_api_vsp.o vspm_api_fdp.o
+ else
+-	${CC} -fPIC -c vspm_api.c -I$(BUILDDIR)/include -Wall
++	${CC} -fPIC -c vspm_api.c -I../include -Wall
+ 	${CC} -shared -Wl,-soname=libvspm.so.1 -o libvspm.so.1.0.0 vspm_api.o
+ endif
+ 	ln -s ./libvspm.so.1.0.0 libvspm.so.1
+-- 
+2.5.0
+

--- a/meta-rcar-gen3/recipes-multimedia/vspmif-module/vspmif-user-module.bb
+++ b/meta-rcar-gen3/recipes-multimedia/vspmif-module/vspmif-user-module.bb
@@ -11,6 +11,10 @@ VSPMIF_LIB_DIR = "vspm_if-module/files/vspm_if"
 
 EXTRA_OEMAKE = "ARCH=${TARGET_ARCH}"
 
+SRC_URI += "file://0001-Do-not-copy-header-files-to-builddir.patch"
+
+includedir="/usr/local/include"
+
 do_compile() {
     export VSPM_LEGACY_IF="1"
 
@@ -32,31 +36,11 @@ do_install() {
     ln -sf libvspm.so.1 libvspm.so
 
     # Copy shared header files
-    install -m 644 ${BUILDDIR}/include/vspm_public.h ${D}/usr/local/include
-    install -m 644 ${BUILDDIR}/include/vsp_drv.h ${D}/usr/local/include
-    install -m 644 ${BUILDDIR}/include/fdp_drv.h ${D}/usr/local/include
-    install -m 644 ${BUILDDIR}/include/fdpm_api.h ${D}/usr/local/include
+    install -m 644 ${S}/${VSPMIF_LIB_DIR}/include/vspm_public.h ${D}/usr/local/include
+    install -m 644 ${S}/${VSPMIF_LIB_DIR}/include/vsp_drv.h ${D}/usr/local/include
+    install -m 644 ${S}/${VSPMIF_LIB_DIR}/include/fdp_drv.h ${D}/usr/local/include
+    install -m 644 ${S}/${VSPMIF_LIB_DIR}/include/fdpm_api.h ${D}/usr/local/include
 }
-
-PACKAGES = "\
-    ${PN} \
-    ${PN}-dev \
-    ${PN}-dbg \
-"
-
-FILES_${PN} = " \
-    ${libdir}/libvspm.so.* \
-"
-
-FILES_${PN}-dev = " \
-    /usr/local/include \
-    /usr/local/include/*.h \
-    ${libdir}/libvspm.so \
-"
-
-FILES_${PN}-dbg = " \
-    ${libdir}/.debug/* \
-"
 
 RPROVIDES_${PN} += "vspmif-user-module"
 INSANE_SKIP_${PN} += "libdir"


### PR DESCRIPTION
The recipe is installing headers directly to the sysroot and so they are not tracked in sstate.
This causes sporadic problems in builds that reuse sstate.

To reproduce the proble,:
- normal setup
- `bitbake vspmif-tp-user-module`
- `mv tmp tmp-old`  (simulates reusing only sstate)
- `bitbake vspmif-tp-user-module -c cleansstate`
- `bitbake vspmif-tp-user-module`
