### PR TITLE
Fix HDMI1 clock issue on H3ULCB

### DIFF
--- a/meta-rcar-gen3/recipes-kernel/linux/linux-renesas/0001-r8a7795-h3ulcb-Fix-dclkin.2-clock.patch
+++ b/meta-rcar-gen3/recipes-kernel/linux/linux-renesas/0001-r8a7795-h3ulcb-Fix-dclkin.2-clock.patch
@@ -1,0 +1,30 @@
+From c114cb18be04406d62a033ccce2fc38a71e2d144 Mon Sep 17 00:00:00 2001
+From: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Date: Tue, 17 Jul 2018 14:59:06 +0300
+Subject: [PATCH] r8a7795-h3ulcb: Fix dclkin.2 clock
+
+With "versaclock5 4" being used as dclkin.2 clock the HDMI1 interface
+doesn't work properly (display which connected to HDMI1 claims that
+there is no signal).
+
+Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+---
+ arch/arm64/boot/dts/renesas/r8a7795-h3ulcb.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/renesas/r8a7795-h3ulcb.dts b/arch/arm64/boot/dts/renesas/r8a7795-h3ulcb.dts
+index 4f15df0..3b70272 100644
+--- a/arch/arm64/boot/dts/renesas/r8a7795-h3ulcb.dts
++++ b/arch/arm64/boot/dts/renesas/r8a7795-h3ulcb.dts
+@@ -94,7 +94,7 @@
+ 		 <&cpg CPG_MOD 727>,
+ 		 <&versaclock5 1>,
+ 		 <&versaclock5_out3>,
+-		 <&versaclock5 4>,
++		 <&versaclock5_out3>,
+ 		 <&versaclock5 2>;
+ 	clock-names = "du.0", "du.1", "du.2", "du.3", "lvds.0",
+ 		      "dclkin.0", "dclkin.1", "dclkin.2", "dclkin.3";
+-- 
+2.7.4
+

--- a/meta-rcar-gen3/recipes-kernel/linux/linux-renesas_4.14.bb
+++ b/meta-rcar-gen3/recipes-kernel/linux/linux-renesas_4.14.bb
@@ -14,9 +14,10 @@ SRCREV = "118adc53e8e9806d76f40859ba96290f289f8839"
 
 SRC_URI = "${RENESAS_BSP_URL};protocol=git;nocheckout=1;branch=${BRANCH}"
 
-# Fix micro SD card issue on M3ULCB
+# Fix micro SD card issue on M3ULCB and HDMI1 clock issue on H3ULCB
 SRC_URI_append = " \
     file://0001-Revert-mmc-renesas_sdhi_internal_dmac-limit-DMA-RX-f.patch \
+    file://0001-r8a7795-h3ulcb-Fix-dclkin.2-clock.patch \
 "
 
 LINUX_VERSION ?= "4.14.35"


### PR DESCRIPTION
It solves the problem with HDMI1 interface which used on extension board.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>