### PR TITLE
rcar-gen3: gstreamer, avb-applications: Replace calls for 'git submodule' with 'gitsm' fetcher.

### DIFF
--- a/meta-rcar-gen3/recipes-multimedia/avb-applications/avb-applications.inc
+++ b/meta-rcar-gen3/recipes-multimedia/avb-applications/avb-applications.inc
@@ -4,5 +4,5 @@ inherit distro_features_check
 
 REQUIRED_DISTRO_FEATURES = "avb"
 
-SRC_URI = "git://github.com/renesas-rcar/avb-applications.git;branch=rcar-gen3"
+SRC_URI = "gitsm://github.com/renesas-rcar/avb-applications.git;branch=rcar-gen3"
 SRCREV = "8398f6e66eaf487eaf8e9a2a8d60f222456c06a6"

--- a/meta-rcar-gen3/recipes-multimedia/avb-applications/avb-demoapps.bb
+++ b/meta-rcar-gen3/recipes-multimedia/avb-applications/avb-demoapps.bb
@@ -16,19 +16,6 @@ S = "${WORKDIR}/git/avb-demoapps"
 
 includedir = "${RENESAS_DATADIR}/include"
 
-# submodule is extracted before do_populate_lic
-addtask do_init_submodule after do_unpack before do_patch
-
-do_init_submodule() {
-    export http_proxy=${http_proxy}
-    export https_proxy=${https_proxy}
-    export HTTP_PROXY=${HTTP_PROXY}
-    export HTTPS_PROXY=${HTTPS_PROXY}
-    cd ${S}
-    git submodule init
-    git submodule update
-}
-
 EXTRA_OEMAKE = "'CC=${CC}' 'AR=${AR}'"
 
 do_install_append() {

--- a/meta-rcar-gen3/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.12.2.bbappend
+++ b/meta-rcar-gen3/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.12.2.bbappend
@@ -1,24 +1,11 @@
 SRC_URI_remove = "http://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz"
-SRC_URI_append = " git://github.com/renesas-rcar/gst-plugins-bad.git;branch=RCAR-GEN3/1.12.2"
+SRC_URI_append = " gitsm://github.com/renesas-rcar/gst-plugins-bad.git;branch=RCAR-GEN3/1.12.2"
 
 SRCREV = "db554fad172f2dabb0f7a75ef1e8e4cb35e172c9"
 
 DEPENDS += "weston"
 
 S = "${WORKDIR}/git"
-
-# submodule is extracted before do_populate_lic
-addtask do_init_submodule after do_unpack before do_patch
-
-do_init_submodule() {
-    export http_proxy=${http_proxy}
-    export https_proxy=${https_proxy}
-    export HTTP_PROXY=${HTTP_PROXY}
-    export HTTPS_PROXY=${HTTPS_PROXY}
-    cd ${S}
-    git submodule init
-    git submodule update
-}
 
 do_configure_prepend() {
     cd ${S}

--- a/meta-rcar-gen3/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.12.2.bbappend
+++ b/meta-rcar-gen3/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.12.2.bbappend
@@ -1,5 +1,5 @@
 SRC_URI_remove = "http://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz"
-SRC_URI_append = " git://github.com/renesas-rcar/gst-plugins-good.git;branch=RCAR-GEN3/1.12.2"
+SRC_URI_append = " gitsm://github.com/renesas-rcar/gst-plugins-good.git;branch=RCAR-GEN3/1.12.2"
 
 SRCREV = "3fd901306fb0fad520e7cbb6a3b0acc79e810700"
 
@@ -11,19 +11,6 @@ EXTRA_OECONF_append = " \
     --enable-cont-frame-capture \
     --enable-ignore-fps-of-video-standard \
 "
-
-# submodule is extracted before do_populate_lic
-addtask do_init_submodule after do_unpack before do_patch
-
-do_init_submodule() {
-    export http_proxy=${http_proxy}
-    export https_proxy=${https_proxy}
-    export HTTP_PROXY=${HTTP_PROXY}
-    export HTTPS_PROXY=${HTTPS_PROXY}
-    cd ${S}
-    git submodule init
-    git submodule update
-}
 
 do_configure_prepend() {
     cd ${S}


### PR DESCRIPTION
Bitbake provides a fetcher which fetches a Git repository with sub-modules, It
is called 'gitsm' [1], it inherits from the 'git://' fetcher, augmenting it with
fetching of sub-modules. 

If gitsm is used, then there is no need to call  'git submodule' manually. Using gitsm has some additional benefits:
 - The recipe is simpler.
 - Submodules are also cached in the download directory(improves the build speed)
 - If used with `BB_GENERATE_MIRROR_TARBALLS`, submodules are included in the mirror tarballs (helps with build reproducability).

[1] https://www.yoctoproject.org/docs/latest/bitbake-user-manual/bitbake-user-manual.html#gitsm-fetcher