### PR TITLE
kernel-module-vspm: Fix SSTATE_DUPWHITELIST to use append syntax.

### DIFF
--- a/meta-rcar-gen3/recipes-kernel/kernel-module-vspm/kernel-module-vspm.bb
+++ b/meta-rcar-gen3/recipes-kernel/kernel-module-vspm/kernel-module-vspm.bb
@@ -61,7 +61,7 @@ do_install () {
 do_populate_sysroot[sstate-inputdirs] += "${S}/${VSPM_DRV_DIR}/include/"
 do_populate_sysroot[sstate-outputdirs] += "${KERNELSRC}/include/"
 do_populate_sysroot_setscene[prefuncs] = "vspm_sstate_check_func"
-SSTATE_DUPWHITELIST = "${KERNELSRC}/include"
+SSTATE_DUPWHITELIST += "${KERNELSRC}/include"
 
 vspm_sstate_check_func() {
     # An error is returned when unpack of kernel source has not been completed yet.


### PR DESCRIPTION
The former overwrote the global default SSTATE_DUPWHITELIST settings from Poky [1].

  SSTATE_DUPWHITELIST = "${DEPLOY_DIR}/licenses/"

This fixes build error:

  ERROR: kernel-module-vspm-1.0-r0 do_populate_lic: The recipe kernel-module-vspm is trying to install files into a shared area when those files already exist. Those files and their manifest location are:
    .../build/tmp/deploy/licenses/kernel-module-vspm/MIT-COPYING
  ...

[1]: https://github.com/openembedded/openembedded-core/blob/2b5c553744804f44a17b61c345e482027e45b71e/meta/classes/sstate.bbclass#L51