### PR TITLE
rcar-gen3: optee-client: fix symlink to libteec.so

### DIFF
--- a/meta-rcar-gen3/recipes-bsp/optee/optee-client_git.bb
+++ b/meta-rcar-gen3/recipes-bsp/optee/optee-client_git.bb
@@ -37,7 +37,7 @@ do_install () {
 
     # Create symbolic link
     cd ${D}/${libdir}
-    ln -sf libteec.so.2.0.0 libteec.so.1.0
+    ln -sf libteec.so.2.0.0 libteec.so.2.0
     ln -sf libteec.so.2.0 libteec.so.2
     ln -sf libteec.so.2 libteec.so
 


### PR DESCRIPTION
fixed the libteec symlink
It was pointing to the old version
libteec.so.2.0.0 -> libteec.so.1.0